### PR TITLE
Composer functionality for Symfony 2.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 BeSimple
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -34,18 +34,25 @@ How to install
 --------------
 
 
-1.  Get the sources via GIT
+### Get the sources
 
-    - Use clone method if not using GIT for your project
+Use Composer method if available
 
-        git clone git://github.com/besimple/DeploymentBundle.git vendor/BeSimple/DeploymentBundle
+    // composer.json
+    "require": {
+        "besimple/deployment-bundle": "dev-master"
+    },
 
-    - Use submodule method if this is the case
+Use submodule method if using GIT but not Composer
 
-        git submodule add git://github.com/besimple/DeploymentBundle.git vendor/BeSimple/DeploymentBundle
+    git submodule add git://github.com/besimple/DeploymentBundle.git vendor/BeSimple/DeploymentBundle
+
+Use clone method if otherwise
+
+    git clone git://github.com/besimple/DeploymentBundle.git vendor/BeSimple/DeploymentBundle
 
 
-2.  Register bundle in `AppKernel` class
+### Register bundle in `AppKernel` class
 
         // app/AppKernel.php
 
@@ -56,7 +63,7 @@ How to install
         );
 
 
-3.  Add `besimple_deployment` entry to your config file
+### Add `besimple_deployment` entry to your config file
 
         # app/config.yml
 
@@ -68,7 +75,8 @@ How to install
             servers:  ~
 
 
-4.  Add `BeSimple` namespace to autoload
+### Add `BeSimple` namespace to autoload
+This step can be skipped if using Composer.
 
         // app/autoload.php
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "besimple/deployment-bundle",
+    "type": "symfony-bundle",
+    "description": "Symfony2 application deployment made easy",
+    "keywords": ["deploy", "rsync", "ssh"],
+    "homepage": "https://github.com/BeSimple/BeSimpleDeploymentBundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jean-François Simon",
+            "email": "contact@jfsimon.fr"
+        },
+        {
+            "name": "BeSimple Community",
+            "homepage": "https://github.com/BeSimple/BeSimpleDeploymentBundle/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "symfony/framework-bundle": "2.*"
+    },
+    "autoload": {
+        "psr-0": { "BeSimple\\DeploymentBundle": "" }
+    },
+    "target-dir" : "BeSimple/DeploymentBundle"
+}


### PR DESCRIPTION
Hi,

I have added a composer.json and updated the documentation so that the bundle can be used with Symfony 2.1. I have also added an MIT license - I hope you don't find this too imposing, but I noticed the BeSimpleI18nRoutingBundle is under MIT. You may like to check the author attributions in the composer.json, as again this was just based on those in BeSimpleI18nRoutingBundle. If you accept this request could you also add the bundle to [Packagist](http://packagist.org)?

Regards,
Tom
